### PR TITLE
Fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/eko/pihole-exporter
+module github.com/robert-figura/pihole-exporter
 
 go 1.20
 

--- a/internal/pihole/client.go
+++ b/internal/pihole/client.go
@@ -7,8 +7,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/eko/pihole-exporter/config"
-	"github.com/eko/pihole-exporter/internal/metrics"
+	"github.com/robert-figura/pihole-exporter/config"
+	"github.com/robert-figura/pihole-exporter/internal/metrics"
 )
 
 type ClientStatus byte

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/eko/pihole-exporter/internal/pihole"
+	"github.com/robert-figura/pihole-exporter/internal/pihole"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"

--- a/main.go
+++ b/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"log"
 
-	"github.com/eko/pihole-exporter/config"
-	"github.com/eko/pihole-exporter/internal/metrics"
-	"github.com/eko/pihole-exporter/internal/pihole"
-	"github.com/eko/pihole-exporter/internal/server"
+	"github.com/robert-figura/pihole-exporter/config"
+	"github.com/robert-figura/pihole-exporter/internal/metrics"
+	"github.com/robert-figura/pihole-exporter/internal/pihole"
+	"github.com/robert-figura/pihole-exporter/internal/server"
 	"github.com/xonvanetta/shutdown/pkg/shutdown"
 )
 


### PR DESCRIPTION
Thanks for your work! Your version still uses the original module names, which makes it impossible to build your fork using

$ go install github.com/Supporterino/pihole-exporter

So until eko accepts your changes maybe you would consider adding a branch where that is fixed. See this pull request for the kind of changes necessary to get there. Obviously, don't just pull my changes, as they refer to my repo's name now, so I could fix this for myself.